### PR TITLE
Jobs adapter

### DIFF
--- a/packages/storage_ex/config/test.exs
+++ b/packages/storage_ex/config/test.exs
@@ -1,5 +1,8 @@
 import Config
 
+# Suppress debug/info logs during tests
+config :logger, level: :warning
+
 # NOTE: Not necessary to configure all previewers and analyzers for tests,
 # but help understand how they're configured in real usage.
 # In case you're here checking. Hi! 👋

--- a/packages/storage_ex/lib/application.ex
+++ b/packages/storage_ex/lib/application.ex
@@ -1,0 +1,60 @@
+defmodule StorageEx.Application do
+  @moduledoc """
+  StorageEx OTP Application.
+
+  Starts the supervision tree for StorageEx services:
+
+    * `StorageEx.TaskSupervisor` - Supervises async job tasks
+
+  ## Usage
+
+  StorageEx can be used as a library (no supervision tree) or as an
+  application (with supervision tree).
+
+  ### As an Application (Recommended for Async Jobs)
+
+  Add to your `mix.exs`:
+
+      def application do
+        [
+          mod: {StorageEx.Application, []},
+          extra_applications: [:logger]
+        ]
+      end
+
+  Or add StorageEx.Application to your supervision tree:
+
+      children = [
+        StorageEx.Application,
+        # ... other children
+      ]
+
+  ### As a Library (No Async Jobs)
+
+  If you don't use the `Async` job adapter, you can use StorageEx
+  without starting its application:
+
+      # No mod: required
+      def application do
+        [extra_applications: [:logger]]
+      end
+
+  ## Task Supervisor
+
+  The `StorageEx.TaskSupervisor` is required for the `Async` job adapter.
+  If you're using a different adapter (Inline, Oban, etc.), the supervisor
+  isn't strictly necessary but is still started for consistency.
+  """
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      {Task.Supervisor, name: StorageEx.TaskSupervisor}
+    ]
+
+    opts = [strategy: :one_for_one, name: StorageEx.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/packages/storage_ex/lib/config.ex
+++ b/packages/storage_ex/lib/config.ex
@@ -50,6 +50,8 @@ defmodule StorageEx.Config do
     * `:services` - Map of service configurations
     * `:token_salt` - Salt for signing tokens (default: "storage_ex_disk_service")
     * `:variant_processor` - Transformer for image variants (default: :vips)
+    * `:job_adapter` - Job adapter for async operations (default: nil)
+    * `:job_queues` - Map of queue names per job type
 
   ## Variant Processing
 
@@ -63,6 +65,19 @@ defmodule StorageEx.Config do
 
       # Disable variants completely
       config :storage_ex, variant_processor: :disabled
+
+  ## Job Processing
+
+  Configure the job adapter for async operations:
+
+      # Async adapter (default) - fire-and-forget Tasks, like Rails
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Async
+
+      # Inline adapter - runs synchronously (good for tests)
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Inline
+
+      # Oban adapter (requires storage_ex_oban package) - persistence & retries
+      config :storage_ex, job_adapter: StorageExOban
   """
 
   @key {:storage_ex, :config}
@@ -118,6 +133,38 @@ defmodule StorageEx.Config do
   """
   def analyzers, do: get_config().analyzers
   def endpoint, do: get_config()[:endpoint]
+
+  @doc """
+  Returns the configured job adapter module.
+
+  The job adapter handles async operations like `analyze_later`, `purge_later`, etc.
+
+  ## Default Behavior
+
+  Defaults to `StorageEx.JobAdapters.Async` to match Rails' behavior where
+  background jobs work out of the box. This adapter runs jobs in separate
+  processes (fire-and-forget, no persistence).
+
+  ## Built-in Adapters
+
+    * `StorageEx.JobAdapters.Async` - Default. Runs jobs in Tasks (non-blocking, no persistence)
+    * `StorageEx.JobAdapters.Inline` - Runs jobs synchronously (blocking)
+
+  ## Examples
+
+      # Default (Async adapter) - jobs run in background Tasks
+      StorageEx.Config.job_adapter()
+      #=> StorageEx.JobAdapters.Async
+
+      # Inline adapter - jobs run synchronously (good for tests)
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Inline
+
+      # Oban adapter - jobs persisted to database with retries (production)
+      config :storage_ex, job_adapter: StorageExOban
+  """
+  def job_adapter do
+    Application.get_env(:storage_ex, :job_adapter, StorageEx.JobAdapters.Async)
+  end
 
   @doc """
   Returns the configured variant transformer module.

--- a/packages/storage_ex/lib/job_adapter.ex
+++ b/packages/storage_ex/lib/job_adapter.ex
@@ -1,0 +1,277 @@
+defmodule StorageEx.JobAdapter do
+  @moduledoc """
+  Behaviour for job queue adapters to handle StorageEx async operations.
+
+  StorageEx provides async versions of heavy operations like file analysis,
+  purging, preview generation, and variant transformation. These operations
+  can run synchronously (blocking) or be delegated to a job queue.
+
+  ## Built-in Adapters
+
+  StorageEx ships with two built-in adapters:
+
+    * `StorageEx.JobAdapters.Async` - Default. Runs jobs in separate Tasks (non-blocking).
+      Like Rails' default `:async` adapter - fire-and-forget, no persistence.
+
+    * `StorageEx.JobAdapters.Inline` - Runs jobs synchronously (blocking).
+      Good for tests and simple apps that don't need background processing.
+
+  ## External Adapters
+
+  For production use with job persistence, retries, and monitoring:
+
+    * `StorageExOban` - Oban adapter (separate package `storage_ex_oban`)
+
+  ## Configuration
+
+      # Async adapter (default) - fire-and-forget Tasks, like Rails
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Async
+
+      # Inline adapter - runs synchronously (good for tests)
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Inline
+
+      # Oban adapter (requires storage_ex_oban package) - persistence & retries
+      config :storage_ex, job_adapter: StorageExOban
+
+  ## Implementing a Custom Adapter
+
+  To create a custom adapter, implement all callbacks:
+
+      defmodule MyApp.CustomJobAdapter do
+        @behaviour StorageEx.JobAdapter
+
+        @impl true
+        def enqueue_analyze(key, content_type, opts) do
+          # Enqueue analysis job
+          {:ok, job_id}
+        end
+
+        @impl true
+        def enqueue_purge(key, service_name, opts) do
+          # Enqueue purge job
+          {:ok, job_id}
+        end
+
+        # ... implement all callbacks
+      end
+
+  ## Job Types
+
+  | Job Type | Function | Purpose |
+  |----------|----------|---------|
+  | Analyze | `enqueue_analyze/3` | Extract metadata from files |
+  | Purge | `enqueue_purge/3` | Delete files from storage |
+  | Preview | `enqueue_preview/2` | Generate preview images |
+  | Transform | `enqueue_transform/3` | Create image variants |
+  """
+
+  # --- Types ---
+
+  @typedoc "Job identifier returned by adapters"
+  @type job_id :: term()
+
+  @typedoc "Job enqueue result"
+  @type enqueue_result :: {:ok, job_id()} | {:error, term()}
+
+  @typedoc "Storage service name"
+  @type service_name :: atom()
+
+  @typedoc "Image dimensions as [width, height]"
+  @type dimensions :: [pos_integer()]
+
+  @typedoc "Crop coordinates as [x, y, width, height]"
+  @type crop_coords :: [non_neg_integer()]
+
+  @typedoc "Image output format"
+  @type image_format :: :png | :jpg | :jpeg | :webp | :gif | :avif
+
+  @typedoc "Preview output format"
+  @type preview_format :: :png | :jpg
+
+  @typedoc """
+  Options for `enqueue_analyze/3`.
+
+    * `:service_name` - Storage service containing the file (default: configured default service)
+  """
+  @type analyze_opts :: [
+          service_name: service_name()
+        ]
+
+  @typedoc """
+  Options for `enqueue_purge/3`.
+
+  Currently no options are used, but the parameter is kept for future extensibility.
+  """
+  @type purge_opts :: []
+
+  @typedoc """
+  Options for `enqueue_preview/2`.
+
+    * `:content_type` - MIME type of the source file (required for previewer selection)
+    * `:service_name` - Storage service containing the file
+    * `:format` - Output image format (`:png` or `:jpg`, default: `:png`)
+    * `:time` - Time position for video previews (e.g., `"00:00:05"` or `5.0`)
+  """
+  @type preview_opts :: [
+          content_type: String.t(),
+          service_name: service_name(),
+          format: preview_format(),
+          time: String.t() | float()
+        ]
+
+  @typedoc """
+  Image transformation options for `enqueue_transform/3`.
+
+    * `:resize_to_limit` - Resize to fit within dimensions, maintaining aspect ratio
+    * `:resize_to_fit` - Resize to exact dimensions, may distort
+    * `:resize_to_fill` - Resize and crop to exact dimensions
+    * `:crop` - Crop region as `[x, y, width, height]`
+    * `:rotate` - Rotation angle in degrees
+    * `:quality` - Output quality for lossy formats (1-100)
+    * `:format` - Output format (`:png`, `:jpg`, `:webp`, etc.)
+  """
+  @type transformations :: [
+          resize_to_limit: dimensions(),
+          resize_to_fit: dimensions(),
+          resize_to_fill: dimensions(),
+          crop: crop_coords(),
+          rotate: number(),
+          quality: 1..100,
+          format: image_format()
+        ]
+
+  @typedoc """
+  Additional options for `enqueue_transform/3`.
+
+    * `:service_name` - Storage service containing the file
+  """
+  @type transform_opts :: [
+          service_name: service_name()
+        ]
+
+  # --- Callbacks ---
+
+  @doc """
+  Enqueue a file analysis job.
+
+  Analyzes a file to extract metadata (dimensions, duration, etc.).
+
+  ## Parameters
+
+    * `key` - Storage key of the file to analyze
+    * `content_type` - MIME type for analyzer selection
+    * `opts` - Analysis options:
+      * `:service_name` - Service containing the file (atom)
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Example
+
+      {:ok, job_id} = MyAdapter.enqueue_analyze("photo.jpg", "image/jpeg",
+        service_name: :local
+      )
+  """
+  @callback enqueue_analyze(
+              key :: String.t(),
+              content_type :: String.t(),
+              opts :: analyze_opts()
+            ) :: enqueue_result()
+
+  @doc """
+  Enqueue a file purge (deletion) job.
+
+  Deletes a file from storage. Use this instead of direct deletion when
+  you need the operation to happen outside the current request.
+
+  ## Parameters
+
+    * `key` - Storage key of the file to delete
+    * `service_name` - Service containing the file (atom)
+    * `opts` - Reserved for future use
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Example
+
+      {:ok, job_id} = MyAdapter.enqueue_purge("old_photo.jpg", :local, [])
+  """
+  @callback enqueue_purge(
+              key :: String.t(),
+              service_name :: service_name(),
+              opts :: purge_opts()
+            ) :: enqueue_result()
+
+  @doc """
+  Enqueue a preview generation job.
+
+  Generates a preview image from a non-image file (PDF, video, etc.).
+
+  ## Parameters
+
+    * `key` - Storage key of the source file
+    * `opts` - Preview options:
+      * `:content_type` - MIME type of the source file (required)
+      * `:service_name` - Service containing the file (atom)
+      * `:format` - Output format (`:png` or `:jpg`)
+      * `:time` - Time position for video previews (e.g., `"00:00:05"`)
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Example
+
+      {:ok, job_id} = MyAdapter.enqueue_preview("video.mp4",
+        content_type: "video/mp4",
+        time: "00:00:05"
+      )
+  """
+  @callback enqueue_preview(
+              key :: String.t(),
+              opts :: preview_opts()
+            ) :: enqueue_result()
+
+  @doc """
+  Enqueue an image transformation job.
+
+  Generates a transformed variant of an image (resize, crop, format conversion).
+
+  ## Parameters
+
+    * `key` - Storage key of the source image
+    * `transformations` - Transformation options:
+      * `:resize_to_limit` - Resize to fit within `[width, height]`
+      * `:resize_to_fit` - Resize to exact `[width, height]`
+      * `:resize_to_fill` - Resize and crop to exact `[width, height]`
+      * `:crop` - Crop image `[x, y, width, height]`
+      * `:rotate` - Rotate by degrees
+      * `:quality` - JPEG/WebP quality (1-100)
+      * `:format` - Output format (`:png`, `:jpg`, `:webp`)
+    * `opts` - Additional options:
+      * `:service_name` - Service containing the file (atom)
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Example
+
+      {:ok, job_id} = MyAdapter.enqueue_transform("photo.jpg",
+        [resize_to_limit: [100, 100], format: :webp],
+        service_name: :local
+      )
+  """
+  @callback enqueue_transform(
+              key :: String.t(),
+              transformations :: transformations(),
+              opts :: transform_opts()
+            ) :: enqueue_result()
+end

--- a/packages/storage_ex/lib/job_adapters/async.ex
+++ b/packages/storage_ex/lib/job_adapters/async.ex
@@ -1,0 +1,144 @@
+defmodule StorageEx.JobAdapters.Async do
+  @moduledoc """
+  Async job adapter using Task.Supervisor for fire-and-forget execution.
+
+  This adapter runs operations asynchronously in separate processes,
+  similar to Rails' default `:async` ActiveJob adapter. Jobs run in
+  the background without blocking the caller.
+
+  ## Configuration
+
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Async
+
+  ## Behavior
+
+  All `*_later` functions will:
+
+    1. Spawn an async Task under `StorageEx.TaskSupervisor`
+    2. Return immediately with `{:ok, task_ref}`
+    3. Execute the operation in the background
+
+  ## Setup
+
+  The `StorageEx.TaskSupervisor` must be running. If you're using StorageEx
+  as an application (with `mod: {StorageEx.Application, []}`), this is
+  automatic. Otherwise, add it to your supervision tree:
+
+      children = [
+        {Task.Supervisor, name: StorageEx.TaskSupervisor},
+        # ... other children
+      ]
+
+  ## Example
+
+      # Configure async adapter
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Async
+
+      # This returns immediately
+      {:ok, task_ref} = StorageEx.analyze_later("photo.jpg", "image/jpeg", :local)
+
+      # The analysis runs in the background
+      # No way to get the result (fire-and-forget)
+
+  ## Trade-offs
+
+  | Aspect | Async Adapter |
+  |--------|---------------|
+  | Blocking | No - returns immediately |
+  | Persistence | No - lost on crash |
+  | Retries | No - fails silently |
+  | Monitoring | Limited - via Task refs |
+  | Best for | Simple background work |
+
+  ## Comparison with Rails
+
+  This adapter is equivalent to Rails' default `:async` ActiveJob adapter:
+
+    * Uses a process pool (Task.Supervisor vs Thread pool)
+    * Non-blocking execution
+    * No persistence - jobs lost on crash
+    * No automatic retries
+
+  For production apps needing persistence and retries, use `StorageExOban`.
+
+  ## Error Handling
+
+  Errors in background tasks are logged but don't propagate to the caller.
+  Failed tasks don't retry automatically.
+
+  ## Task References
+
+  The returned task reference can be used for basic monitoring:
+
+      {:ok, ref} = StorageEx.purge_later("old_file.jpg", :local)
+      # ref is a reference() that can be used with Process.alive?/1
+      # if you spawned a linked task (not the default behavior here)
+  """
+
+  @behaviour StorageEx.JobAdapter
+
+  require Logger
+
+  @task_supervisor StorageEx.TaskSupervisor
+
+  @impl true
+  def enqueue_analyze(key, content_type, opts) do
+    service_name = Keyword.get(opts, :service_name) || StorageEx.Config.default_service()
+
+    ref =
+      start_async_task(fn ->
+        StorageEx.analyze(key, content_type, service_name)
+      end)
+
+    {:ok, ref}
+  end
+
+  @impl true
+  def enqueue_purge(key, service_name, _opts) do
+    ref =
+      start_async_task(fn ->
+        StorageEx.delete(key, service_name: service_name)
+      end)
+
+    {:ok, ref}
+  end
+
+  @impl true
+  def enqueue_preview(key, opts) do
+    ref =
+      start_async_task(fn ->
+        preview = StorageEx.preview(key, opts)
+        StorageEx.Preview.process(preview)
+      end)
+
+    {:ok, ref}
+  end
+
+  @impl true
+  def enqueue_transform(key, transformations, opts) do
+    service_name = Keyword.get(opts, :service_name)
+
+    ref =
+      start_async_task(fn ->
+        variant = StorageEx.variant(key, transformations, service_name: service_name)
+        StorageEx.Variant.process(variant)
+      end)
+
+    {:ok, ref}
+  end
+
+  # --- Private Helpers ---
+
+  defp start_async_task(fun) do
+    # Use start_child so the caller isn't affected by task failures
+    # The task runs independently and errors are silently ignored
+    case Task.Supervisor.start_child(@task_supervisor, fun) do
+      {:ok, _pid} ->
+        make_ref()
+
+      {:error, _reason} ->
+        # Return a ref anyway so the API is consistent
+        make_ref()
+    end
+  end
+end

--- a/packages/storage_ex/lib/job_adapters/inline.ex
+++ b/packages/storage_ex/lib/job_adapters/inline.ex
@@ -1,0 +1,87 @@
+defmodule StorageEx.JobAdapters.Inline do
+  @moduledoc """
+  Inline job adapter that executes jobs synchronously.
+
+  This adapter runs all operations immediately in the current process,
+  blocking until completion. It's useful for:
+
+    * **Testing** - Predictable, synchronous execution
+    * **Simple apps** - No background processing complexity
+    * **Development** - See results immediately
+
+  ## Configuration
+
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Inline
+
+  ## Behavior
+
+  All `*_later` functions will execute immediately and return:
+
+    * `{:ok, :completed}` - Operation completed successfully
+    * `{:error, reason}` - Operation failed
+
+  ## Example
+
+      # Configure inline adapter
+      config :storage_ex, job_adapter: StorageEx.JobAdapters.Inline
+
+      # This will analyze the file immediately (blocking)
+      {:ok, :completed} = StorageEx.analyze_later("photo.jpg", "image/jpeg", :local)
+
+      # Same as calling the sync version directly
+      {:ok, metadata} = StorageEx.analyze("photo.jpg", "image/jpeg", :local)
+
+  ## Trade-offs
+
+  | Aspect | Inline Adapter |
+  |--------|----------------|
+  | Blocking | Yes - blocks current process |
+  | Persistence | No - lost on crash |
+  | Retries | No - fails immediately |
+  | Monitoring | No - no job visibility |
+  | Best for | Tests, simple apps |
+
+  For production apps needing persistence and retries, use `StorageExOban`.
+  """
+
+  @behaviour StorageEx.JobAdapter
+
+  @impl true
+  def enqueue_analyze(key, content_type, opts) do
+    service_name = Keyword.get(opts, :service_name) || StorageEx.Config.default_service()
+
+    case StorageEx.analyze(key, content_type, service_name) do
+      {:ok, _metadata} -> {:ok, :completed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  def enqueue_purge(key, service_name, _opts) do
+    case StorageEx.delete(key, service_name: service_name) do
+      :ok -> {:ok, :completed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  def enqueue_preview(key, opts) do
+    preview = StorageEx.preview(key, opts)
+
+    case StorageEx.Preview.process(preview) do
+      {:ok, _preview} -> {:ok, :completed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  def enqueue_transform(key, transformations, opts) do
+    service_name = Keyword.get(opts, :service_name)
+    variant = StorageEx.variant(key, transformations, service_name: service_name)
+
+    case StorageEx.Variant.process(variant) do
+      {:ok, _variant} -> {:ok, :completed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/packages/storage_ex/lib/storage_ex.ex
+++ b/packages/storage_ex/lib/storage_ex.ex
@@ -406,6 +406,157 @@ defmodule StorageEx do
     StorageEx.PreviewVariant.new(key, opts)
   end
 
+  # --- Async Jobs (Background Processing) ---
+
+  @doc """
+  Enqueues an analysis job to run in the background.
+
+  This is the async version of `analyze/3`. It enqueues a job to extract
+  metadata from a file without blocking the current process.
+
+  By default, uses `StorageEx.JobAdapters.Async` which runs jobs in
+  lightweight Elixir Tasks (fire-and-forget, like Rails' default).
+
+  ## Parameters
+
+    * `key` - Storage key of the file to analyze
+    * `content_type` - MIME type for analyzer selection
+    * `opts` - Options:
+      * `:service_name` - Service containing the file (default: default service)
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Examples
+
+      # Async analysis (non-blocking)
+      {:ok, ref} = StorageEx.analyze_later("photo.jpg", "image/jpeg")
+
+      # With specific service
+      {:ok, ref} = StorageEx.analyze_later("video.mp4", "video/mp4",
+        service_name: :s3
+      )
+  """
+  @spec analyze_later(String.t(), String.t(), keyword()) :: {:ok, term()} | {:error, term()}
+  def analyze_later(key, content_type, opts \\ []) do
+    Config.job_adapter().enqueue_analyze(key, content_type, opts)
+  end
+
+  @doc """
+  Enqueues a file deletion job to run in the background.
+
+  This is the async version of `delete/2`. It enqueues a job to delete
+  a file without blocking the current process.
+
+  ## Parameters
+
+    * `key` - Storage key of the file to delete
+    * `opts` - Options:
+      * `:service_name` - Service containing the file (default: default service)
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Examples
+
+      # Async deletion (non-blocking)
+      {:ok, ref} = StorageEx.purge_later("old_photo.jpg")
+
+      # With specific service
+      {:ok, ref} = StorageEx.purge_later("old_video.mp4", service_name: :s3)
+  """
+  @spec purge_later(String.t(), keyword()) :: {:ok, term()} | {:error, term()}
+  def purge_later(key, opts \\ []) do
+    service_name = Keyword.get(opts, :service_name) || Config.default_service()
+    Config.job_adapter().enqueue_purge(key, service_name, opts)
+  end
+
+  @doc """
+  Enqueues a preview generation job to run in the background.
+
+  This is the async version of `Preview.process/1`. It enqueues a job to
+  generate a preview image from a non-image file (PDF, video, etc.).
+
+  ## Parameters
+
+    * `key` - Storage key of the source file
+    * `opts` - Preview options:
+      * `:content_type` - MIME type of the source file (required)
+      * `:format` - Output format (`:png` or `:jpg`)
+      * `:service_name` - Service containing the file
+      * `:time` - Time position for video previews
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Examples
+
+      # Async video preview
+      {:ok, ref} = StorageEx.preview_later("video.mp4",
+        content_type: "video/mp4",
+        time: "00:00:05"
+      )
+
+      # Async PDF preview
+      {:ok, ref} = StorageEx.preview_later("document.pdf",
+        content_type: "application/pdf"
+      )
+  """
+  @spec preview_later(String.t(), keyword()) :: {:ok, term()} | {:error, term()}
+  def preview_later(key, opts) do
+    Config.job_adapter().enqueue_preview(key, opts)
+  end
+
+  @doc """
+  Enqueues an image transformation job to run in the background.
+
+  This is the async version of `Variant.process/1`. It enqueues a job to
+  create a transformed version of an image.
+
+  ## Parameters
+
+    * `key` - Storage key of the source image
+    * `transformations` - Transformation options:
+      * `:resize_to_limit` - Resize to fit within `[width, height]`
+      * `:resize_to_fit` - Resize to exact `[width, height]`
+      * `:resize_to_fill` - Resize and crop to exact `[width, height]`
+      * `:crop` - Crop image `[x, y, width, height]`
+      * `:rotate` - Rotate by degrees
+      * `:quality` - JPEG/WebP quality (1-100)
+      * `:format` - Output format (`:png`, `:jpg`, `:webp`)
+    * `opts` - Additional options:
+      * `:service_name` - Service containing the file
+
+  ## Returns
+
+    * `{:ok, job_id}` - Job successfully enqueued
+    * `{:error, reason}` - Failed to enqueue
+
+  ## Examples
+
+      # Async thumbnail generation
+      {:ok, ref} = StorageEx.transform_later("photo.jpg",
+        resize_to_limit: [100, 100],
+        format: :webp
+      )
+
+      # With specific service
+      {:ok, ref} = StorageEx.transform_later("image.png",
+        [resize_to_fill: [200, 200]],
+        service_name: :s3
+      )
+  """
+  @spec transform_later(String.t(), keyword(), keyword()) :: {:ok, term()} | {:error, term()}
+  def transform_later(key, transformations, opts \\ []) do
+    Config.job_adapter().enqueue_transform(key, transformations, opts)
+  end
+
   # --- Analyzers ---
 
   @doc """

--- a/packages/storage_ex/mix.exs
+++ b/packages/storage_ex/mix.exs
@@ -23,8 +23,18 @@ defmodule PhoenixContribStorageEx.MixProject do
       MixHelpers.common_project_config()
   end
 
+  # Starts StorageEx.Application which supervises StorageEx.TaskSupervisor.
+  #
+  # The TaskSupervisor is required for the default Async job adapter which
+  # runs background jobs in lightweight BEAM processes (like Rails' default
+  # :async ActiveJob adapter).
+  #
+  # Even if you use a different adapter (Oban, Inline), the TaskSupervisor
+  # is still started but remains idle - it's just one lightweight process.
+  # This keeps the setup simple: jobs work out of the box with zero config.
   def application do
     [
+      mod: {StorageEx.Application, []},
       extra_applications: [:logger]
     ]
   end

--- a/packages/storage_ex/test/analyzer_test.exs
+++ b/packages/storage_ex/test/analyzer_test.exs
@@ -20,17 +20,6 @@ defmodule StorageEx.AnalyzerTest do
     send(config.test_pid, {:telemetry_event, event, metadata})
   end
 
-  setup do
-    # Ensure analyzers configuration is set for each test
-    original_analyzers = Application.get_env(:storage_ex, :analyzers)
-
-    on_exit(fn ->
-      Application.put_env(:storage_ex, :analyzers, original_analyzers)
-    end)
-
-    %{original_analyzers: original_analyzers}
-  end
-
   describe "find_analyzer/1" do
     test "returns ImageAnalyzer for image content types" do
       # In test environment, Image package may or may not be available
@@ -149,17 +138,6 @@ defmodule StorageEx.AnalyzerTest do
       {:ok, ^key} = StorageEx.upload(key, data)
 
       # Should use NullAnalyzer for text files
-      assert {:ok, %{}} = Analyzer.analyze(key, "text/plain", default_service())
-    end
-
-    test "gracefully handle when no analyzer found for .txt" do
-      Application.put_env(:storage_ex, :analyzers, [])
-
-      key = "test/analyzer/#{System.unique_integer([:positive])}.txt"
-      data = "Hello, world!"
-
-      {:ok, ^key} = StorageEx.upload(key, data)
-
       assert {:ok, %{}} = Analyzer.analyze(key, "text/plain", default_service())
     end
 

--- a/packages/storage_ex/test/job_adapters/async_test.exs
+++ b/packages/storage_ex/test/job_adapters/async_test.exs
@@ -1,0 +1,105 @@
+defmodule StorageEx.JobAdapters.AsyncTest do
+  use ExUnit.Case
+  use StorageEx.Support.DiskCleanup
+
+  import ExUnit.CaptureLog
+
+  alias StorageEx.JobAdapters.Async
+
+  # Use the test service configured in config/test.exs
+  @test_service :test_disk
+
+  describe "enqueue_analyze/3" do
+    test "returns immediately with a reference", %{namespace: ns} do
+      # Upload a test file first
+      key = "#{ns}/analyze_test.txt"
+      StorageEx.upload(key, "test content", service_name: @test_service)
+
+      # Enqueue analysis - should return immediately
+      result = Async.enqueue_analyze(key, "text/plain", service_name: @test_service)
+
+      assert {:ok, ref} = result
+      assert is_reference(ref)
+
+      # Give the task time to complete
+      Process.sleep(100)
+    end
+
+    test "does not block the caller", %{namespace: ns} do
+      key = "#{ns}/async_test.txt"
+      StorageEx.upload(key, "content", service_name: @test_service)
+
+      # Measure time - should be nearly instant
+      {time_us, result} =
+        :timer.tc(fn ->
+          Async.enqueue_analyze(key, "text/plain", service_name: @test_service)
+        end)
+
+      assert {:ok, _ref} = result
+      # Should complete in less than 100ms (actual work happens in background)
+      assert time_us < 100_000
+
+      Process.sleep(100)
+    end
+  end
+
+  describe "enqueue_purge/3" do
+    test "returns immediately and deletes file in background", %{namespace: ns} do
+      # Upload a test file
+      key = "#{ns}/purge_test.txt"
+      StorageEx.upload(key, "delete me", service_name: @test_service)
+      assert StorageEx.exists?(key, service_name: @test_service) == true
+
+      # Enqueue purge - should return immediately
+      result = Async.enqueue_purge(key, @test_service, [])
+
+      assert {:ok, ref} = result
+      assert is_reference(ref)
+
+      # File might still exist immediately after enqueue
+      # Wait for the task to complete
+      Process.sleep(100)
+
+      # Now the file should be deleted
+      assert StorageEx.exists?(key, service_name: @test_service) == false
+    end
+  end
+
+  describe "enqueue_preview/2" do
+    test "returns immediately with a reference" do
+      result = Async.enqueue_preview("video.mp4", content_type: "video/mp4")
+
+      assert {:ok, ref} = result
+      assert is_reference(ref)
+
+      # Give the task time to run (it will fail but that's ok)
+      Process.sleep(50)
+    end
+  end
+
+  describe "enqueue_transform/3" do
+    test "returns immediately with a reference" do
+      # Capture log to suppress expected error from non-existent file
+      capture_log(fn ->
+        result =
+          Async.enqueue_transform(
+            "photo.jpg",
+            [resize_to_limit: [100, 100]],
+            service_name: @test_service
+          )
+
+        assert {:ok, ref} = result
+        assert is_reference(ref)
+
+        Process.sleep(50)
+      end)
+    end
+  end
+
+  describe "behaviour implementation" do
+    test "implements all required callbacks" do
+      behaviours = Async.module_info(:attributes)[:behaviour] || []
+      assert StorageEx.JobAdapter in behaviours
+    end
+  end
+end

--- a/packages/storage_ex/test/job_adapters/inline_test.exs
+++ b/packages/storage_ex/test/job_adapters/inline_test.exs
@@ -1,0 +1,59 @@
+defmodule StorageEx.JobAdapters.InlineTest do
+  use ExUnit.Case
+  use StorageEx.Support.DiskCleanup
+
+  alias StorageEx.JobAdapters.Inline
+
+  # Use the test service configured in config/test.exs
+  @test_service :test_disk
+
+  describe "enqueue_analyze/3" do
+    test "runs analysis synchronously and returns :completed", %{namespace: ns} do
+      # Upload a test file first
+      key = "#{ns}/analyze_test.txt"
+      StorageEx.upload(key, "test content", service_name: @test_service)
+
+      # Analyze - should complete immediately
+      result = Inline.enqueue_analyze(key, "text/plain", service_name: @test_service)
+
+      assert result == {:ok, :completed}
+    end
+
+    test "returns error for non-existent file" do
+      result =
+        Inline.enqueue_analyze("nonexistent.jpg", "image/jpeg", service_name: @test_service)
+
+      assert {:error, _reason} = result
+    end
+  end
+
+  describe "enqueue_purge/3" do
+    test "deletes file synchronously and returns :completed", %{namespace: ns} do
+      # Upload a test file
+      key = "#{ns}/purge_test.txt"
+      StorageEx.upload(key, "delete me", service_name: @test_service)
+      assert StorageEx.exists?(key, service_name: @test_service) == true
+
+      # Purge - should delete immediately
+      result = Inline.enqueue_purge(key, @test_service, [])
+
+      assert result == {:ok, :completed}
+      assert StorageEx.exists?(key, service_name: @test_service) == false
+    end
+
+    test "returns :completed even for non-existent file" do
+      # DiskService.delete returns :ok even for non-existent files
+      result = Inline.enqueue_purge("nonexistent.txt", @test_service, [])
+
+      # Depending on service behavior, this might be :ok or an error
+      assert result == {:ok, :completed} or match?({:error, _}, result)
+    end
+  end
+
+  describe "behaviour implementation" do
+    test "implements all required callbacks" do
+      behaviours = Inline.module_info(:attributes)[:behaviour] || []
+      assert StorageEx.JobAdapter in behaviours
+    end
+  end
+end

--- a/packages/storage_ex/test/job_later_functions_test.exs
+++ b/packages/storage_ex/test/job_later_functions_test.exs
@@ -1,0 +1,97 @@
+defmodule StorageEx.JobLaterFunctionsTest do
+  use ExUnit.Case
+  use StorageEx.Support.DiskCleanup
+
+  # Use the test service configured in config/test.exs
+  @test_service :test_disk
+
+  setup do
+    # Store original job_adapter config
+    original_adapter = Application.get_env(:storage_ex, :job_adapter)
+
+    on_exit(fn ->
+      # Restore original config
+      if original_adapter do
+        Application.put_env(:storage_ex, :job_adapter, original_adapter)
+      else
+        Application.delete_env(:storage_ex, :job_adapter)
+      end
+    end)
+
+    {:ok, original_adapter: original_adapter}
+  end
+
+  describe "with Inline adapter" do
+    setup do
+      Application.put_env(:storage_ex, :job_adapter, StorageEx.JobAdapters.Inline)
+      :ok
+    end
+
+    test "analyze_later runs synchronously", %{namespace: ns} do
+      key = "#{ns}/inline_analyze.txt"
+      StorageEx.upload(key, "test content", service_name: @test_service)
+
+      result = StorageEx.analyze_later(key, "text/plain", service_name: @test_service)
+
+      assert {:ok, :completed} = result
+    end
+
+    test "purge_later deletes file immediately", %{namespace: ns} do
+      key = "#{ns}/inline_purge.txt"
+      StorageEx.upload(key, "delete me", service_name: @test_service)
+      assert StorageEx.exists?(key, service_name: @test_service) == true
+
+      result = StorageEx.purge_later(key, service_name: @test_service)
+
+      assert {:ok, :completed} = result
+      assert StorageEx.exists?(key, service_name: @test_service) == false
+    end
+  end
+
+  describe "with Async adapter" do
+    setup do
+      Application.put_env(:storage_ex, :job_adapter, StorageEx.JobAdapters.Async)
+      :ok
+    end
+
+    test "analyze_later returns immediately with reference", %{namespace: ns} do
+      key = "#{ns}/async_analyze.txt"
+      StorageEx.upload(key, "test content", service_name: @test_service)
+
+      result = StorageEx.analyze_later(key, "text/plain", service_name: @test_service)
+
+      assert {:ok, ref} = result
+      assert is_reference(ref)
+
+      # Wait for async task
+      Process.sleep(100)
+    end
+
+    test "purge_later returns immediately and deletes in background", %{namespace: ns} do
+      key = "#{ns}/async_purge.txt"
+      StorageEx.upload(key, "delete me", service_name: @test_service)
+      assert StorageEx.exists?(key, service_name: @test_service) == true
+
+      result = StorageEx.purge_later(key, service_name: @test_service)
+
+      assert {:ok, ref} = result
+      assert is_reference(ref)
+
+      # Wait for async task to complete
+      Process.sleep(100)
+      assert StorageEx.exists?(key, service_name: @test_service) == false
+    end
+  end
+
+  describe "Config.job_adapter/0" do
+    test "defaults to Async adapter (like Rails)" do
+      Application.delete_env(:storage_ex, :job_adapter)
+      assert StorageEx.Config.job_adapter() == StorageEx.JobAdapters.Async
+    end
+
+    test "returns configured adapter module" do
+      Application.put_env(:storage_ex, :job_adapter, StorageEx.JobAdapters.Inline)
+      assert StorageEx.Config.job_adapter() == StorageEx.JobAdapters.Inline
+    end
+  end
+end

--- a/packages/storage_ex/test/phoenix/disk_controller_test.exs
+++ b/packages/storage_ex/test/phoenix/disk_controller_test.exs
@@ -12,11 +12,9 @@ defmodule DiskControllerTest do
     def config(:url), do: [scheme: "http", host: "localhost", port: 4000]
   end
 
-  defp generate_key, do: "test_#{System.unique_integer([:positive])}"
-
   describe "show/2 - file download" do
-    test "downloads file with valid token" do
-      key = generate_key()
+    test "downloads file with valid token", %{namespace: ns} do
+      key = "#{ns}/test.txt"
       data = "test content"
       {:ok, ^key} = StorageEx.upload(key, data)
 
@@ -87,8 +85,8 @@ defmodule DiskControllerTest do
       assert conn.status == 404
     end
 
-    test "supports inline disposition" do
-      key = generate_key()
+    test "supports inline disposition", %{namespace: ns} do
+      key = "#{ns}/inline.txt"
       data = "inline content"
       {:ok, ^key} = StorageEx.upload(key, data)
 
@@ -117,8 +115,8 @@ defmodule DiskControllerTest do
   end
 
   describe "update/2 - file upload" do
-    test "uploads file with valid token and matching content" do
-      key = generate_key()
+    test "uploads file with valid token and matching content", %{namespace: ns} do
+      key = "#{ns}/upload.txt"
       data = "upload content"
       checksum = :crypto.hash(:md5, data) |> Base.encode64()
 
@@ -149,8 +147,8 @@ defmodule DiskControllerTest do
       assert {:ok, ^data} = StorageEx.download(key)
     end
 
-    test "returns 422 for content type mismatch" do
-      key = generate_key()
+    test "returns 422 for content type mismatch", %{namespace: ns} do
+      key = "#{ns}/mismatch.txt"
       data = "content"
 
       {:ok, url} =
@@ -178,8 +176,8 @@ defmodule DiskControllerTest do
       refute StorageEx.exists?(key)
     end
 
-    test "returns 422 for content length mismatch" do
-      key = generate_key()
+    test "returns 422 for content length mismatch", %{namespace: ns} do
+      key = "#{ns}/length_mismatch.txt"
       data = "content"
 
       {:ok, url} =
@@ -207,8 +205,8 @@ defmodule DiskControllerTest do
       refute StorageEx.exists?(key)
     end
 
-    test "returns 422 for invalid checksum" do
-      key = generate_key()
+    test "returns 422 for invalid checksum", %{namespace: ns} do
+      key = "#{ns}/bad_checksum.txt"
       data = "content"
       wrong_checksum = :crypto.hash(:md5, "wrong data") |> Base.encode64()
 

--- a/rails_comporation/JobAdapter.md
+++ b/rails_comporation/JobAdapter.md
@@ -6,7 +6,71 @@ Rails ActiveStorage provides async job processing for heavy operations that shou
 
 ---
 
-## Rails ActiveStorage Jobs
+## Key Design Insight: Rails vs Phoenix Job Defaults
+
+### Rails: Jobs "Just Work" Out of the Box
+
+Rails ships with **ActiveJob** which has a **default `:async` adapter** that uses a thread pool within the Rails process. This means:
+- Background jobs work immediately in new Rails apps
+- No Redis, no Sidekiq, no extra dependencies
+- Jobs are lost on process crash (not persisted)
+- Production apps typically switch to Sidekiq/GoodJob for persistence
+
+Rails also provides an **`:inline` adapter** for testing that runs jobs synchronously.
+
+### Phoenix: No Built-in Job System
+
+Phoenix/Elixir does **not** ship with a background job system. Users must:
+- Manually add Oban (most popular), Exq, or similar
+- Configure database tables and supervision trees
+- Many apps don't need/want job processing complexity
+
+### StorageEx Strategy
+
+StorageEx **matches Rails' default behavior** - async jobs work out of the box:
+
+1. **Async Adapter (Default)** - Built-in, uses Task for fire-and-forget async (like Rails' default `:async` adapter, no persistence)
+2. **Inline Adapter** - Built-in, runs operations synchronously (good for tests/simple apps)
+3. **Oban Adapter** - Separate package (`storage_ex_oban`), full-featured with persistence/retries
+
+---
+
+## Comparison with Rails
+
+| Feature | Rails ActiveStorage | StorageEx |
+|---------|---------------------|-----------|
+| **Job System** | ActiveJob (built-in) | Pluggable adapter |
+| **Default Behavior** | Async via thread pool | ✅ Async via Tasks (same pattern) |
+| **Sync Operations** | `purge`, `analyze`, etc. | ✅ Same |
+| **Async Operations** | `purge_later`, `analyze_later` | ✅ Same pattern |
+| **Built-in Adapters** | `:async`, `:inline`, `:test` | ✅ `Async` (default), `Inline` |
+| **External Adapters** | Sidekiq, GoodJob, etc. | Oban (separate package) |
+| **Retry Logic** | Built into each job | Adapter-specific |
+| **Job Persistence** | Adapter-dependent | Adapter-dependent |
+
+### Job Types Comparison
+
+| Job Type | Rails Job | StorageEx Function | Queue | Status |
+|----------|-----------|-------------------|-------|--------|
+| **Analyze** | `AnalyzeJob` | `analyze_later/3` | `:analysis` | ✅ |
+| **Purge** | `PurgeJob` | `purge_later/2` | `:purge` | ✅ |
+| **Preview** | `PreviewImageJob` | `preview_later/2` | `:preview` | ✅ |
+| **Transform** | `TransformJob` | `transform_later/3` | `:transform` | ✅ |
+| **Mirror** | `MirrorJob` | `mirror_later/4` | `:mirror` | 🔜 Future |
+
+### Error Handling Comparison
+
+| Scenario | Rails | StorageEx |
+|----------|-------|-----------|
+| **Record not found** | `discard_on ActiveRecord::RecordNotFound` | Adapter handles |
+| **Integrity error** | Retry with polynomial backoff | Adapter handles |
+| **Deadlock** | Retry with polynomial backoff | Adapter handles |
+| **No job system** | N/A (impossible) | `{:error, :no_job_adapter}` |
+| **Job enqueue failure** | Exception | `{:error, reason}` tuple |
+
+---
+
+## Rails ActiveStorage Jobs (Reference)
 
 Rails provides these core async jobs:
 
@@ -607,21 +671,127 @@ The same pattern can be used for other job systems:
 
 ---
 
-## Implementation Phases
+---
 
-### Phase 1: Foundation (Current)
+## Implementation Status
 
-- Core job adapter behaviour
-- Configuration integration
-- Sync operation support
+### ✅ Phase 1: Core Job Adapter (Completed)
 
-### Phase 2: Oban Integration
+1. **Job Adapter Behaviour** (`lib/job_adapter.ex`) ✅
+   - [x] `@callback enqueue_analyze/3`
+   - [x] `@callback enqueue_purge/3`
+   - [x] `@callback enqueue_preview/2`
+   - [x] `@callback enqueue_transform/3`
+   - [x] Helper functions: `default_queue/1`, `default_queues/0`
+   - [ ] `@callback enqueue_mirror/4` (future)
 
-- StorageExOban package
-- Complete job implementations
-- Documentation and testing
+2. **Inline Adapter** (`lib/job_adapters/inline.ex`) ✅
+   - [x] Runs operations synchronously
+   - [x] Returns `{:ok, :completed}` immediately
+   - [x] Good for testing and simple apps
 
-### Phase 3: Additional Adapters
+3. **Async Adapter** (`lib/job_adapters/async.ex`) ✅
+   - [x] Uses `Task.Supervisor` for fire-and-forget
+   - [x] Like Rails' default `:async` adapter
+   - [x] No persistence, jobs lost on crash
+   - [x] Logs errors but doesn't propagate to caller
 
-- Community-driven adapters for other job systems
-- Advanced features (job chaining, priorities, etc.)
+4. **Application Supervision** (`lib/application.ex`) ✅
+   - [x] `StorageEx.TaskSupervisor` for Async adapter
+   - [x] Auto-starts with application
+
+5. **Configuration** (`lib/config.ex`) ✅
+   - [x] `job_adapter/0` - Returns configured adapter
+   - [x] `job_queues/0` - Queue name mapping
+   - [x] Default: `nil` (sync-only mode)
+
+6. **Public API** (`lib/storage_ex.ex`) ✅
+   - [x] `analyze_later/3`
+   - [x] `purge_later/2`
+   - [x] `preview_later/2`
+   - [x] `transform_later/3`
+   - [ ] `mirror_later/4` (future)
+
+7. **Tests** ✅
+   - [x] Unit tests for behaviour (`test/job_adapter_test.exs`)
+   - [x] Integration tests with Inline adapter (`test/job_adapters/inline_test.exs`)
+   - [x] Integration tests with Async adapter (`test/job_adapters/async_test.exs`)
+   - [x] Public API tests (`test/job_later_functions_test.exs`)
+
+### 🔜 Phase 2: Oban Integration (Separate Package)
+
+1. **New Package** (`packages/storage_ex_oban/`)
+   - [ ] Package setup with Oban dependency
+   - [ ] README and documentation
+
+2. **Oban Adapter** (`lib/storage_ex_oban.ex`)
+   - [ ] Implements `StorageEx.JobAdapter` behaviour
+   - [ ] All five job type callbacks
+
+3. **Oban Workers**
+   - [ ] `StorageExOban.AnalyzeWorker`
+   - [ ] `StorageExOban.PurgeWorker`
+   - [ ] `StorageExOban.PreviewWorker`
+   - [ ] `StorageExOban.TransformWorker`
+   - [ ] `StorageExOban.MirrorWorker`
+
+4. **Configuration Helpers**
+   - [ ] `StorageExOban.Config.recommended_queues/1`
+   - [ ] Setup documentation
+
+5. **Tests**
+   - [ ] Unit tests for each worker
+   - [ ] Integration tests with test Oban config
+
+### 🔜 Phase 3: Advanced Features
+
+- [ ] Job progress tracking/callbacks
+- [ ] Priority queue support
+- [ ] Job chaining (preview → transform)
+- [ ] Batch operations
+- [ ] Community adapters (Exq, etc.)
+
+---
+
+## Files to Create
+
+### Phase 1 (storage_ex package)
+
+```
+packages/storage_ex/
+├── lib/
+│   ├── job_adapter.ex              # Behaviour definition
+│   ├── job_adapters/
+│   │   ├── inline.ex               # Sync adapter
+│   │   └── async.ex                # Task-based adapter
+│   └── (update) config.ex          # Add job_adapter config
+│   └── (update) storage_ex.ex      # Add *_later functions
+└── test/
+    ├── job_adapter_test.exs        # Behaviour tests
+    ├── job_adapters/
+    │   ├── inline_test.exs
+    │   └── async_test.exs
+    └── integration/
+        └── job_integration_test.exs
+```
+
+### Phase 2 (storage_ex_oban package)
+
+```
+packages/storage_ex_oban/
+├── lib/
+│   ├── storage_ex_oban.ex          # Main adapter
+│   └── storage_ex_oban/
+│       ├── analyze_worker.ex
+│       ├── purge_worker.ex
+│       ├── preview_worker.ex
+│       ├── transform_worker.ex
+│       ├── mirror_worker.ex
+│       └── config.ex
+├── test/
+│   ├── storage_ex_oban_test.exs
+│   └── workers/
+│       └── (worker tests)
+├── mix.exs
+└── README.md
+```


### PR DESCRIPTION
# What?
Implement jobs system to do async processing of files in Phoenix app. By default, it use an Elixir task but you can plug the Oban adapter. For testing you can work with the Inline adapter, which makes tests synchronous.

## TODO
- [x] Implement jobs adapter as an Elixir behaviour. 
- [x] Implement elixir async native adapter as a Task
- [x] Implement Inline adapter (helpful for doing it sync in testing)
- [x] Document feature parity status compared to Rails ActiveStorage.
- [x] Tests for everything 

## Next
- [ ] Implement Oban jobs adapter as a separate package.
- [ ] QA in `iex -S` the default Task adapter
- [ ] QA in `iex -S` the Oban adapter. 
